### PR TITLE
Change Travis to Github Actions workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies and run tests.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Build and test Welcome Demo
+
+on:
+  workflow_dispatch:
+  push:
+    # When PRs are merged to master, run tests on the HEAD of master.
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    # When PRs are opened or updated, run tests on the merge commit
+    # for branches that would be merged into master.
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test with custom validation script
+      run: |
+        python validate.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-    - "3.7"
-dist: xenial
-script:
-    - python validate.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# welcome-demo [![Build Status](https://travis-ci.org/infolab-csail/welcome-demo.svg)](https://travis-ci.org/infolab-csail/welcome-demo)
+# welcome-demo 
+[![Build Status](https://github.com/infolab-csail/welcome-demo/actions/workflows/python-package.yml/badge.svg?branch=master)](https://github.com/infolab-csail/welcome-demo/actions/workflows/python-package.yml)
+
 Welcome to the InfoLab! Please follow these instructions to get familiar with our lab's Github workflow.
 
 ## Steps
@@ -30,7 +32,7 @@ named `welcome-demo`. `cd` to it.
    that editor.)
 
 1. Create a [pull request](https://help.github.com/articles/using-pull-requests/) (PR) with your changes.
-1. Wait for [Travis](https://travis-ci.org/infolab-csail/welcome-demo)
+1. Wait for [Github Actions](https://github.com/infolab-csail/welcome-demo/actions/workflows/python-package.yml)
 checks to pass. If checks fail, your change probably broke the format
 of the `numbers.csv` file. Make modifications by pushing more changes
 to the `add-<yourname>-fav-num` branch.


### PR DESCRIPTION
Even though we still have Travis for public open-source repos such as
`welcome-demo`, it's best that we train students in our actual
continuous integration software.

Partially resolves Issue
https://github.com/infolab-csail/infolab-core/issues/255.

Similar to PR https://github.com/infolab-csail/astroparse/pull/117.